### PR TITLE
Fix V3025

### DIFF
--- a/src/Extensions/Wizards/Views/ReferencedAssemblyResolutionRule.cs
+++ b/src/Extensions/Wizards/Views/ReferencedAssemblyResolutionRule.cs
@@ -46,13 +46,13 @@
 
             try
             {
-                Debug.WriteLine( "Attempting to load assembly '{0}' into a reflection-only context from {1}.", new[] { item.Name, location } );
+                Debug.WriteLine( "Attempting to load assembly '{0}' into a reflection-only context from {1}.", item.Name, location);
                 return Assembly.ReflectionOnlyLoadFrom( location );
             }
             catch
             {
                 // resolution failed
-                Debug.WriteLine( "Failed to load assembly '{0}' into a reflection-only context.", new[] { item.Name } );
+                Debug.WriteLine( "Failed to load assembly '{0}' into a reflection-only context.", item.Name);
                 return null;
             }
         }


### PR DESCRIPTION
 Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- Incorrect format. A different number of format items is expected while calling 'WriteLine' function. Format items not used: {1}. Wizards ReferencedAssemblyResolutionRule.cs 49