### PR TITLE
Fix V3025

### DIFF
--- a/src/Extensions/Wizards/Views/RelativeAssemblyResolutionRule.cs
+++ b/src/Extensions/Wizards/Views/RelativeAssemblyResolutionRule.cs
@@ -33,13 +33,13 @@
 
             try
             {
-                Debug.WriteLine( "Attempting to load assembly '{0}' into a reflection-only context from {1}.", new[] { item.Name, assemblyFile } );
+                Debug.WriteLine( "Attempting to load assembly '{0}' into a reflection-only context from {1}.", item.Name, assemblyFile);
                 return Assembly.ReflectionOnlyLoadFrom( assemblyFile );
             }
             catch
             {
                 // resolution failed
-                Debug.WriteLine( "Failed to load assembly '{0}' into a reflection-only context.", new[] { item.Name } );
+                Debug.WriteLine( "Failed to load assembly '{0}' into a reflection-only context.", item.Name);
                 return null;
             }
         }


### PR DESCRIPTION
 Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- Incorrect format. A different number of format items is expected while calling 'WriteLine' function. Format items not used: {1}. Wizards RelativeAssemblyResolutionRule.cs 36