### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/src/More.AspNet.Hosting.Mvc/More.AspNet.Hosting.Mvc.csproj
+++ b/src/More.AspNet.Hosting.Mvc/More.AspNet.Hosting.Mvc.csproj
@@ -8,7 +8,16 @@
   <Description>The Microsoft ASP.NET MVC hosting library for the "More" framework.</Description>
   <RootNamespace>More</RootNamespace>
   <PackageTags>More;Patterns;Practices;Hosting;aspnet;mvc;ui;User Interface</PackageTags>
- </PropertyGroup>
+ 
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
  <!-- 
  <ItemGroup>

--- a/src/More.AspNet.Hosting.WebApi/More.AspNet.Hosting.WebApi.csproj
+++ b/src/More.AspNet.Hosting.WebApi/More.AspNet.Hosting.WebApi.csproj
@@ -8,7 +8,16 @@
   <Description>The Microsoft ASP.NET Web API hosting library for the "More" framework.</Description>
   <RootNamespace>More</RootNamespace>
   <PackageTags>More;Patterns;Practices;Hosting;aspnet;webapi</PackageTags>
- </PropertyGroup>
+ 
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
  <!--
  <ItemGroup>

--- a/src/More.AspNet.Hosting/More.AspNet.Hosting.csproj
+++ b/src/More.AspNet.Hosting/More.AspNet.Hosting.csproj
@@ -9,7 +9,16 @@
   <RootNamespace>More</RootNamespace>
   <PackageTags>More;Patterns;Practices;aspnet;Web;Hosting;User Interface;UI</PackageTags>
   <DefineConstants>$(DefineConstants);ASPNET</DefineConstants>
- </PropertyGroup>
+ 
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
  <ItemGroup>
   <ReleaseNotes Include="Host now resolves settings by key and type" />

--- a/src/More.Composition/More.Composition.csproj
+++ b/src/More.Composition/More.Composition.csproj
@@ -8,7 +8,16 @@
   <Description>The composition library for the "More" framework.</Description>
   <RootNamespace>More.Composition</RootNamespace>
   <PackageTags>More;Patterns;Practices;Composition;MEF</PackageTags>
- </PropertyGroup>
+ 
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
  <ItemGroup>
   <ReleaseNotes Include="Updated TFM to .NET Standard" />

--- a/src/More.Extensions/More.Extensions.csproj
+++ b/src/More.Extensions/More.Extensions.csproj
@@ -106,7 +106,15 @@
  <Target Name="AdjustReferringTargetFrameworkForUAP" BeforeTargets="GetTargetFrameworkProperties">
   <PropertyGroup Condition="'$(ReferringTargetFramework)' == '.NETCore,Version=v5.0'">
    <ReferringTargetFramework>UAP,Version=v10.0</ReferringTargetFramework>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
  </Target>
 
 </Project>

--- a/src/More.UI.Hosting/More.UI.Hosting.csproj
+++ b/src/More.UI.Hosting/More.UI.Hosting.csproj
@@ -66,7 +66,15 @@
  <Target Name="AdjustReferringTargetFrameworkForUAP" BeforeTargets="GetTargetFrameworkProperties">
   <PropertyGroup Condition="'$(ReferringTargetFramework)' == '.NETCore,Version=v5.0'">
    <ReferringTargetFramework>UAP,Version=v10.0</ReferringTargetFramework>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
  </Target>
 
 </Project>

--- a/src/More.UI.Presentation/More.UI.Presentation.csproj
+++ b/src/More.UI.Presentation/More.UI.Presentation.csproj
@@ -128,7 +128,15 @@
  <Target Name="AdjustReferringTargetFrameworkForUAP" BeforeTargets="GetTargetFrameworkProperties">
   <PropertyGroup Condition="'$(ReferringTargetFramework)' == '.NETCore,Version=v5.0'">
    <ReferringTargetFramework>UAP,Version=v10.0</ReferringTargetFramework>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
  </Target>
 
 </Project>

--- a/src/More.UI/More.UI.csproj
+++ b/src/More.UI/More.UI.csproj
@@ -8,7 +8,16 @@
   <Description>The user interface foundation library for the "More" framework.</Description>
   <RootNamespace>More</RootNamespace>
   <PackageTags>More;Patterns;Practices;UI;User Interfaces;Model;View;MVVM;MVC;MVP</PackageTags>
- </PropertyGroup>
+ 
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
  <ItemGroup>
   <ReleaseNotes Include="Updated TFM to .NET Standard" />

--- a/src/More.Validation/More.Validation.csproj
+++ b/src/More.Validation/More.Validation.csproj
@@ -8,7 +8,16 @@
   <Description>The validation library for the "More" framework.</Description>
   <RootNamespace>More.ComponentModel.DataAnnotations</RootNamespace>
   <PackageTags>More;Patterns;Practices;Validation;Annotations</PackageTags>
- </PropertyGroup>
+ 
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
  <ItemGroup>
   <ReleaseNotes Include="Updated TFM to .NET Standard" />

--- a/src/More/More.csproj
+++ b/src/More/More.csproj
@@ -8,7 +8,16 @@
   <Description>The core library for the "More" framework.</Description>
   <RootNamespace>More</RootNamespace>
   <PackageTags>More;Patterns;Practices</PackageTags>
- </PropertyGroup>
+ 
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
  <ItemGroup>
   <ReleaseNotes Include="Updated TFM to .NET Standard" />

--- a/src/Sdk/More.VisualStudio.Editors/More.VisualStudio.Editors.csproj
+++ b/src/Sdk/More.VisualStudio.Editors/More.VisualStudio.Editors.csproj
@@ -5,7 +5,16 @@
   <TargetFrameworks>net46</TargetFrameworks>
   <AssemblyTitle>More - Visual Studio Editors</AssemblyTitle>
   <Description>The editors and code generators for the "More" framework used by Microsoft Visual Studio.</Description>
- </PropertyGroup>
+ 
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
  <ItemGroup>
   <PackageReference Include="EnvDTE" Version="8.0.0" />

--- a/src/Sdk/More.VisualStudio.TemplateWizards/More.VisualStudio.TemplateWizards.csproj
+++ b/src/Sdk/More.VisualStudio.TemplateWizards/More.VisualStudio.TemplateWizards.csproj
@@ -79,7 +79,15 @@
  <Target Name="WorkaroundForXAMLIntellisenseBuildIssue" AfterTargets="_CheckCompileDesignTimePrerequisite">
   <PropertyGroup>
    <BuildingProject>false</BuildingProject>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
  </Target>
 
  <Import Project="..\..\Shared\Shared.projitems" Label="Shared" />


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
